### PR TITLE
synopsys remove, BD add

### DIFF
--- a/tab_tool_support.md
+++ b/tab_tool_support.md
@@ -95,7 +95,7 @@ If you have access to other DAST Tools, PLEASE RUN THEM FOR US against the Bench
 * [Contrast Assess](https://www.contrastsecurity.com/contrast-assess) - .log results file
 	* You can scan Benchmark w/Contrast Assess for free. See: [https://www.contrastsecurity.com/contrast-community-edition](https://www.contrastsecurity.com/contrast-community-edition)
 * [Datadog Application Vulnerability Management](https://www.datadoghq.com/product/application-vulnerability-management/) - .log results file
-* [Synopsys Seeker IAST](https://www.synopsys.com/software-integrity/security-testing/interactive-application-security-testing.html) - .csv results file
+* [Black Duck Seeker IAST](https://www.blackduck.com/interactive-application-security-testing.html) - .csv results file
 
 **Commercial Hybrid Analysis Application Security Testing Tools:**
 


### PR DESCRIPTION
synopsys does not own black duck or it's products anymore, black duck is a standalone cyber tooling company. changed link and reference.